### PR TITLE
chore: tailor CODEOWNERS for Dependabot (engineering-platform).

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Dependabot dependency manifests — @vantage-sh/engineering-platform
+# Tailored from .github/dependabot.yml + repo manifests (ecosystems: github-actions, npm, pre-commit, terraform).
+/.github/workflows/**/* @vantage-sh/engineering-platform
+/.pre-commit-config.yaml @vantage-sh/engineering-platform
+/.pre-commit-config.yml @vantage-sh/engineering-platform
+/.pre-commit.yaml @vantage-sh/engineering-platform
+/.pre-commit.yml @vantage-sh/engineering-platform
+/.terraform.lock.hcl @vantage-sh/engineering-platform
+/**/*.tf @vantage-sh/engineering-platform
+/**/*.tfvars @vantage-sh/engineering-platform
+/npm-shrinkwrap.json @vantage-sh/engineering-platform
+/package-lock.json @vantage-sh/engineering-platform
+/package.json @vantage-sh/engineering-platform
+/pnpm-lock.yaml @vantage-sh/engineering-platform
+/yarn.lock @vantage-sh/engineering-platform


### PR DESCRIPTION
Assign `@vantage-sh/engineering-platform` as CODEOWNERS for Dependabot-related paths only (from `.github/dependabot.yml` plus repo manifest inference).

- **core**: updates `config/teams/engineering_platform.yml` and regenerated `.github/CODEOWNERS` entries for bundler, npm, docker, and docker-compose; GitHub Actions remain under existing `.github/**/*` ownership.
- **Other repos**: `.github/CODEOWNERS` lists only manifests for the ecosystems this repo uses.

Regenerate across the org later with: `node generate-tailored-dependabot-codeowners.mjs` at the ghorg root (repos other than `core`).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new `.github/CODEOWNERS` file to route reviews for dependency/infra manifest changes; no runtime code or behavior is affected.
> 
> **Overview**
> Introduces a new `.github/CODEOWNERS` that assigns `@vantage-sh/engineering-platform` as owners for Dependabot-relevant files, including GitHub Actions workflows, npm manifests/lockfiles, pre-commit configs, and Terraform files/lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e21eb307d7626b1d39323c2047849425ea06cc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Related to PLA-1407