### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 30
+  - package-ecosystem: 'pre-commit'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 30
+  - package-ecosystem: 'terraform'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 30
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 30


### PR DESCRIPTION
Dependabot could be enabled for this repository. Please enable it by merging this pull request so that we can keep our dependencies up to date and secure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds `.github/dependabot.yaml` and does not change runtime code; the main impact is increased automated PR activity from dependency bumps.
> 
> **Overview**
> Enables Dependabot by adding `.github/dependabot.yaml` to schedule **weekly** update checks for `npm`, `pre-commit`, `terraform`, and `github-actions`, with a `30`-day cooldown between update attempts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e72d7c7d02b6759590acac9ab424400a893b7859. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->